### PR TITLE
WIP: support klipse macros

### DIFF
--- a/resources/public/src/klipse/macros.clj
+++ b/resources/public/src/klipse/macros.clj
@@ -1,0 +1,11 @@
+(ns klipse.macros)
+
+(defmacro dbg[x]
+  `(let [x# ~x]
+     (print (str '~x ": " x#))
+     x#))
+
+(defmacro disp [& forms]
+  (cons `str (for [form forms]
+               `(str (pr-str '~form) " => " (pr-str ~form) "\n"))))
+

--- a/src/klipse/compiler.cljs
+++ b/src/klipse/compiler.cljs
@@ -32,10 +32,12 @@
                     ))
 
 (def repl-opts-noop (merge (replumb/options :browser
-                                             ["/dbg/js" "/js/compiled/out"]
-                                             io/no-op)
+                                             ["src" "/fig/js"]
+                                             io/fetch-file!)
                             {:warning-as-error false
                              :context :statement
+                             :src-paths ["src" "/fig/js"]
+                             :cache {:src-paths-lookup? true}
                              :verbose false}))
 
 (defn read-string-cond [s]

--- a/src/klipse/macros.clj
+++ b/src/klipse/macros.clj
@@ -1,0 +1,7 @@
+(ns klipse.macros)
+
+(defmacro dbg[x]
+  (when *assert*
+  `(let [x# ~x]
+     (print (str '~x ": " x#))
+     x#)))


### PR DESCRIPTION
@raphaelboukara macros can be used in KLIPSE but there is a timing issue. It doesn't work with cljs_in. It works only on subsequent evaluations.

For instance try this [klipse with macros](http://localhost:5014/index-dbg.html?cljs_in=(ns%20my.test%0A%20%20(%3Arequire-macros%20%5Bklipse.macros%20%3Aas%20m%5D))%0A%0A(m%2Fdisp%20(map%20inc%20%5B1%202%203%204%5D)))