### PR TITLE
Add support to the klipse plugin for data-preamble="(def foo 2)".

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ The following attributes can be added to the DOM element of the snippet:
 * `data-eval-context`: (default `statement`) indicates the evaluation context that will be passed to cljs/eval-str. One in `expr`, `statement`, `return`.  Sometimes snippets with a single expression are evaluated to `nil`. Use `data-eval-context=expr` when your snippet contains a single expression like `(let [a 4] a)`.
 * `data-external-libs`: comma separated list of github repositories to resolve dependencies: you need to provide the full list of dependencies (including the dependencies of dependencies recursively). See for instance [Lambda Caclulus with clojure and Klipse](http://blog.klipse.tech/lambda/2016/07/24/lambda-calculus-2.html)
 * `data-print-length`: (default 1000) max number of items in collections to display - useful to prevent browser stuck when evaluating infinite sequences like `(range)`
+* `data-preamble`: (default nil) A string containing Clojurescript source code that should be run before the contents of this snippet, eg "(reset! canvas-id :canvas-2)". Useful for hiding implementation details from readers in blog posts, like e.g. setting a `canvas-id` atom to `:canvas-2`, or for performing any other setup operations that need to be done on a per-snippet basis.
 * `data-beautify-strings`: (default false) when evaluation result is a string - display the "interior" of the string without escaping the quotes.
 * `data-verbose`: (default false) passed to boostrapped `eval` and `compile` `:verbose` opts
 

--- a/resources/public/plugin-dev.html
+++ b/resources/public/plugin-dev.html
@@ -113,6 +113,12 @@
        <div class="clojure-js">(map inc [100000 2 3])</div>
     <h2> data-static-fns=true </h2>
 <div class="clojure-js" data-static-fns="true">(map inc [100000 2 3])</div>
+
+    <h2> data-preamble </h2>
+
+    <p>This snippet prepends (def preamble-var 2) to its cljs source code.</p>
+
+    <div class="clojure" data-preamble="(def preamble-var 2)">(= (+ preamble-var 3) 5)</div>
       
     <h1> styling </h1>
     <p> Leading and trailing blank lines should be removed. Other empty lines should be kept.</p>
@@ -305,7 +311,7 @@ letter_frequency("aabbcccdfdfsfd").sort_by {|key, val| -val}.each {|pair| p pair
         <script src="https://asmblah.github.io/uniter/dist/uniter.js"></script>
         <script src="http://www.skulpt.org/static/skulpt.min.js" type="text/javascript"></script> 
         <script src="http://www.skulpt.org/static/skulpt-stdlib.js" type="text/javascript"></script> 
-    <script src="http://www.biwascheme.org/release/biwascheme-0.6.6.min.js"></script>
+    <script src="http://www.biwascheme.org/release/biwascheme-0.6.6-min.js"></script>
         <script src="plugin/js/klipse_plugin.js"></script>
     </body>
 </html>

--- a/src/klipse/args_from_element.cljs
+++ b/src/klipse/args_from_element.cljs
@@ -40,6 +40,7 @@
         static-fns (read-string-or-val (aget my-dataset "staticFns") false)
         verbose (read-string-or-val (aget my-dataset "verbose") false)
         eval-context (read-string-or-val (aget my-dataset "evalContext") eval-context)
+        preamble (aget my-dataset "preamble")
         print-length (read-string-or-val (aget my-dataset "printLength") print-length)
         beautify-strings (read-string-or-val (aget my-dataset "beautifyStrings") beautify-strings)
         external-libs (string->array (or (aget my-dataset "externalLibs") nil))]
@@ -47,6 +48,7 @@
      :print-length print-length
      :external-libs external-libs
      :context eval-context
+     :preamble preamble
      :verbose verbose
      :beautify-strings beautify-strings}))
 

--- a/src/klipse/compiler.cljs
+++ b/src/klipse/compiler.cljs
@@ -104,7 +104,7 @@
           :no-pr-str-on-value true
           :context (or context :statement)}))
 
-(defmethod core-eval :replumb [s {:keys [preamble static-fns context verbose external-libs] :or {preamble nil static-fns false context nil external-libs nil}} cb]
+(defmethod core-eval :replumb [s {:keys [preamble static-fns context verbose external-libs] :or {preamble "" static-fns false context nil external-libs nil}} cb]
   (let [opts (build-repl-opts {:static-fns static-fns
                                :external-libs external-libs
                                :verbose verbose
@@ -115,7 +115,7 @@
 (defn my-eval [{:keys [file source file lang name path cache] :as args}]
   (cljs/js-eval args))
 
-(defmethod core-eval :core [s {:keys [preamble static-fns context external-libs verbose] :or {preamble nil static-fns false context nil external-libs nil}} cb]
+(defmethod core-eval :core [s {:keys [preamble static-fns context external-libs verbose] :or {preamble "" static-fns false context nil external-libs nil}} cb]
   ; we have to set `env/*compiler*` because `binding` and core.async don't play well together (https://www.reddit.com/r/Clojure/comments/4wrjw5/withredefs_doesnt_play_well_with_coreasync/) and the code of `eval-str` uses `binding` of `env/*compiler*`.
   (cljs/eval-str (create-state-eval)
                  (str preamble s)

--- a/src/klipse/compiler.cljs
+++ b/src/klipse/compiler.cljs
@@ -104,21 +104,21 @@
           :no-pr-str-on-value true
           :context (or context :statement)}))
 
-(defmethod core-eval :replumb [s {:keys [static-fns context verbose external-libs] :or {static-fns false context nil external-libs nil}} cb]
+(defmethod core-eval :replumb [s {:keys [preamble static-fns context verbose external-libs] :or {preamble nil static-fns false context nil external-libs nil}} cb]
   (let [opts (build-repl-opts {:static-fns static-fns
                                :external-libs external-libs
                                :verbose verbose
                                :context (keyword context)})]
     (! js/window.COMPILED true); for some reason it is required with read-eval-call
-    (replumb/read-eval-call opts cb s)))
+    (replumb/read-eval-call opts cb (str preamble s))))
 
 (defn my-eval [{:keys [file source file lang name path cache] :as args}]
   (cljs/js-eval args))
 
-(defmethod core-eval :core [s {:keys [static-fns context external-libs verbose] :or {static-fns false context nil external-libs nil}} cb]
+(defmethod core-eval :core [s {:keys [preamble static-fns context external-libs verbose] :or {preamble nil static-fns false context nil external-libs nil}} cb]
   ; we have to set `env/*compiler*` because `binding` and core.async don't play well together (https://www.reddit.com/r/Clojure/comments/4wrjw5/withredefs_doesnt_play_well_with_coreasync/) and the code of `eval-str` uses `binding` of `env/*compiler*`.
   (cljs/eval-str (create-state-eval)
-                 s
+                 (str preamble s)
                  "my.klipse" {:eval my-eval
                               :def-emits-var true
                               :verbose verbose


### PR DESCRIPTION
The contents of a snippet's `data-preamble` field are run before the
snippet's cljs source code. Useful for letting blog authors hide
implementation details from their readers.