### PR TITLE
Fixes text selection width issue

### DIFF
--- a/resources/public/css/codemirror.css
+++ b/resources/public/css/codemirror.css
@@ -311,7 +311,7 @@ div.CodeMirror-dragcursors {
   visibility: visible;
 }
 
-.CodeMirror-selected { background: #d9d9d9; }
+.CodeMirror-selected { background: #d9d9d9; min-width: 0;}
 .CodeMirror-focused .CodeMirror-selected { background: #d7d4f0; }
 .CodeMirror-crosshair { cursor: crosshair; }
 .CodeMirror-line::selection, .CodeMirror-line > span::selection, .CodeMirror-line > span > span::selection { background: #d7d4f0; }

--- a/resources/public/shadowdom-dbg.html
+++ b/resources/public/shadowdom-dbg.html
@@ -326,7 +326,7 @@ div.CodeMirror-dragcursors {
   visibility: visible;
 }
 
-.CodeMirror-selected { background: #d9d9d9; }
+.CodeMirror-selected { background: #d9d9d9; min-width: 0;}
 .CodeMirror-focused .CodeMirror-selected { background: #d7d4f0; }
 .CodeMirror-crosshair { cursor: crosshair; }
 .CodeMirror-line::selection, .CodeMirror-line > span::selection, .CodeMirror-line > span > span::selection { background: #d7d4f0; }


### PR DESCRIPTION
This was caused by the `min-width` of the `CodeMirror-selected` div being set to `inherit`, and it inheriting a value of `313px` from `CodeMirror-sizer`.

Issue:
![broken](https://user-images.githubusercontent.com/20938000/34429258-f8e7e268-ec12-11e7-8a97-47d0c44d579b.gif)

Once fixed:
![working](https://user-images.githubusercontent.com/20938000/34429290-8438474a-ec13-11e7-8e05-d0e78ad31a55.gif)
