### PR TITLE
Issue 340 ruby parsing error fix

### DIFF
--- a/resources/public/ruby-dbg.html
+++ b/resources/public/ruby-dbg.html
@@ -16,7 +16,7 @@ file .
 split(//) .
 group_by {|letter| letter.downcase} .
 select   {|key, val| letters.include? key} .
-collect  {|key, val| [key, val.length]}
+collect  {|key, val| [key, val.length]} 
 end
 
 letter_frequency("aabbcccdfdfsfd").sort_by {|key, val| -val}
@@ -44,14 +44,11 @@ letter_frequency("aabbcccdfdfsfd").sort_by {|key, val| -val}
     def anynacci(start_sequence, count)
   n = start_sequence.length    # Get the n-step for the type of fibonacci sequence
   result = start_sequence.dup  # Create a new result array with the values copied from the array that was passed by reference
-
   (n+1..count).each do         # Loop for the remaining results up to count
     result << result.last(n).reduce(:+)    # Get the last n element from result and append its total to Array
   end
-
   result                       # Return result
 end
-
 naccis = { lucus:      [2,1],
            fibonacci:  [1,1],
            tribonacci: [1,1,2],
@@ -62,11 +59,9 @@ naccis = { lucus:      [2,1],
            octonacci:  [1,1,2,4,8,16,32,64],
            nonanacci:  [1,1,2,4,8,16,32,64,128],
            decanacci:  [1,1,2,4,8,16,32,64,128,256] }
-
 def nacci(naccis, count=15)
   naccis.map {|name, seq| "%12s : %p \n" % [name, anynacci(seq, count)]}
 end
-
 nacci(naccis)
     </div>
         <script>

--- a/resources/public/ruby-dbg.html
+++ b/resources/public/ruby-dbg.html
@@ -16,26 +16,42 @@ file .
 split(//) .
 group_by {|letter| letter.downcase} .
 select   {|key, val| letters.include? key} .
-collect  {|key, val| [key, val.length]} 
+collect  {|key, val| [key, val.length]}
 end
 
-letter_frequency("aabbcccdfdfsfd").sort_by {|key, val| -val}.each {|pair| p pair}
+letter_frequency("aabbcccdfdfsfd").sort_by {|key, val| -val}
 
             </div>
+<br/>
+<div class="eval-ruby">
+  def sum(num1, num2)
+    num1 + num2
+  end
+
+  sum(3, 4)
+</div>
+<br/>
+<div class="eval-ruby">
+  def greet(name)
+    "Hello, #{name} :)"
+  end
+
+  greet("Sam")
+</div>
 <br/>
 <div class="eval-ruby">
 #https://www.rosettacode.org/wiki/Fibonacci_n-step_number_sequences
     def anynacci(start_sequence, count)
   n = start_sequence.length    # Get the n-step for the type of fibonacci sequence
   result = start_sequence.dup  # Create a new result array with the values copied from the array that was passed by reference
- 
+
   (n+1..count).each do         # Loop for the remaining results up to count
     result << result.last(n).reduce(:+)    # Get the last n element from result and append its total to Array
   end
- 
+
   result                       # Return result
 end
- 
+
 naccis = { lucus:      [2,1],
            fibonacci:  [1,1],
            tribonacci: [1,1,2],
@@ -46,11 +62,11 @@ naccis = { lucus:      [2,1],
            octonacci:  [1,1,2,4,8,16,32,64],
            nonanacci:  [1,1,2,4,8,16,32,64,128],
            decanacci:  [1,1,2,4,8,16,32,64,128,256] }
- 
+
 def nacci(naccis, count=15)
   naccis.map {|name, seq| "%12s : %p \n" % [name, anynacci(seq, count)]}
 end
- 
+
 nacci(naccis)
     </div>
         <script>
@@ -58,7 +74,6 @@ nacci(naccis)
             selector_eval_ruby: '.eval-ruby'
         };
         </script>
-        <script src="/lib/mirror_extensions.js"></script>
-        <script src="/fig/js/klipse.fig.js"></script>
+        <script src="/cljs-out/dev-main.js"></script>
     </body>
 </html>

--- a/src/klipse/lang/ruby.cljs
+++ b/src/klipse/lang/ruby.cljs
@@ -13,12 +13,15 @@
 
 (def load-opal-parser-once (runonce load-opal-parser))
 
+(defn not-enumerable [obj]
+  (if (or (number? obj) (string? obj)) true))
+
 (defn str-eval-async [exp _]
   (go
     (load-opal-parser-once)
     (try
       (let [res (j/call js/Opal :eval exp)]
-        (j/call res :$inspect))
+        (if (not-enumerable res) (str res) (j/call res :$inspect)))
       (catch js/Object e
         (str e)))))
 

--- a/src/klipse/lang/ruby.cljs
+++ b/src/klipse/lang/ruby.cljs
@@ -14,7 +14,7 @@
 (def load-opal-parser-once (runonce load-opal-parser))
 
 (defn not-enumerable [obj]
-  (if (or (number? obj) (string? obj)) true))
+  (or (number? obj) (string? obj)))
 
 (defn str-eval-async [exp _]
   (go


### PR DESCRIPTION
NB I haven't completed the deployment steps as it's not clear from the documentation when this should happen (before or after PR merge). If I need to complete those steps before this branch can be merged please let me know.

This PR includes two fixes:

1) Fixes the Ruby test page, as this was not loading. Also adds two simple examples to cover Numeric and String values.

2) Adds a type check to the Ruby string eval function, and will only attempt to call `inspect` on objects that are not strings, numbers or symbols. Instead, it will convert those types to string. This isn't a great fix, but without making a bigger change and replacing `js-interop` it's the best I could do. Errors are still returned as normal.

I'd be really grateful if you could review this ASAP and give me comments if needed, please keep in mind that I am new to Clojure 🙏

Fixes #340 