### PR TITLE
Securize: Increase isolation by stripping away prototypes

### DIFF
--- a/src/klipse/utils.cljs
+++ b/src/klipse/utils.cljs
@@ -126,10 +126,10 @@
   (set! secured-eval true)
   (let [original-eval js/eval]
     (j/assoc! js/window :eval (fn [src]
-                        (original-eval (str "with (klipse_eval_sandbox){ " src "}"))))
+                        (original-eval (str ";(function(){with (this){ " src "}}).call(klipse_eval_sandbox)"))))
     (set! eval-in-global-scope js/eval)
     (j/assoc! js/window :klipse_unsecured_eval original-eval)
-    (j/assoc! js/window :klipse_eval_sandbox (clj->js (zipmap the-forbidden-symbols (repeat {}))))
+    (j/assoc! js/window :klipse_eval_sandbox (clj->js (zipmap the-forbidden-symbols (repeat (js/Object.create nil)))))
     #_(set! js/klipse-eval-sandbox (clj->js (zipmap (js/Object.getOwnPropertyNames js/window) (repeat {}))))
     #_(doseq [sym permitted-symbols]
       (aset js/klipse-eval-sandbox sym (aget js/window sym)))))


### PR DESCRIPTION
See #247 
See #339 

When we assign our new `(secured-eval)` we've been allowing the `window`
property to bleed through as `this`. Additionally we have been setting
our forbidden symbols as the empty object `{}` which also exposes the
`Object` prototype.

In this patch we're replacing both of those in an attempt to further
limit the extent to which scripts can access global data.

The downside to this approach is that we've lost all prototypes that we
want, such as `Array.prototype.map`. The severity of this limitation is
so high that it's probably unmergable, but I'm hoping there might still
be a way to resolve that.