### PR TITLE
Add link shortening

### DIFF
--- a/src/klipse/ui/editors/common.cljs
+++ b/src/klipse/ui/editors/common.cljs
@@ -1,14 +1,12 @@
 (ns klipse.ui.editors.common
-  (:require-macros 
+  (:require-macros
    [gadjett.core :refer [dbg]])
   (:require
    [klipse.ui.editors.editor :as editor]
    [klipse.utils :refer [url-parameters create-url-with-input debounce]]))
 
 (defn display-url-with-input [base-url value]
-  (doto (create-url-with-input base-url value)
-    print
-    js/alert))
+  (create-url-with-input base-url value))
 
 (defn refresh-with-code [base-url value]
   (js/location.replace (create-url-with-input base-url value)))

--- a/src/klipse/utils.cljs
+++ b/src/klipse/utils.cljs
@@ -15,7 +15,7 @@
   a shortened version for the user to copy."
   [current]
   (go (let [response (<! (http/get
-      "https://cutt.ly/api/api.php"
+      "https://cors-anywhere.herokuapp.com/https://cutt.ly/api/api.php"
       {:with-credentials? false
       :headers {"accept" "application/json" "content-type" "application/json"}
       :query-params {:key "ba890e6ad3b5e17911e7762c5677aa26e29c9" :short current}}))]

--- a/src/klipse/utils.cljs
+++ b/src/klipse/utils.cljs
@@ -15,27 +15,22 @@
   a shortened version for the user to copy."
   [current]
   (go (let [response (<! (http/get
-      "https://cors-anywhere.herokuapp.com/https://cutt.ly/api/api.php"
+      "https://cors-anywhere.herokuapp.com/https://is.gd/create.php"
       {:with-credentials? false
       :headers {"accept" "application/json" "content-type" "application/json"}
-      :query-params {:key "ba890e6ad3b5e17911e7762c5677aa26e29c9" :short current}}))]
-      (let [short-link (goog.object/getValueByKeys (.parse js/JSON (:body response)) "url" "shortLink")]
-        (if (some? short-link)
-          (
-            (js/alert short-link)
-            (print short-link)
-          )
-          (
-            (js/alert current)
-            (print current)
-          )
-        )
-      )
+      :query-params {:format "simple" :url current}}))]
       (if-not (= (:status response) 200)
           (
             (js/alert current)
             (print current)
-          ))
+          )
+          (let [short-link (:body response)]
+          (
+            (js/alert short-link)
+            (print short-link)
+          )
+      )
+          )
   ))
 )
 

--- a/src/klipse/utils.cljs
+++ b/src/klipse/utils.cljs
@@ -11,7 +11,7 @@
    [applied-science.js-interop :as j]))
 
 (defn fetch-shortened-url
-  "Calls the Cutt.ly API with the current URL and returns
+  "Calls is.gd with the current URL and returns
   a shortened version for the user to copy."
   [current]
   (go (let [response (<! (http/get

--- a/src/klipse/utils.cljs
+++ b/src/klipse/utils.cljs
@@ -15,7 +15,7 @@
   a shortened version for the user to copy."
   [current]
   (go (let [response (<! (http/get
-      "https://cors-anywhere.herokuapp.com/https://cutt.ly/api/api.php"
+      "https://cutt.ly/api/api.php"
       {:with-credentials? false
       :headers {"accept" "application/json" "content-type" "application/json"}
       :query-params {:key "ba890e6ad3b5e17911e7762c5677aa26e29c9" :short current}}))]


### PR DESCRIPTION
Closes #130 

Uses the [Cutt.ly API](https://cutt.ly/cuttly-api) to generate a short link when the user hits `Ctrl+S`. If there's an issue generating the short link, the current URL is returned instead.

Checking with the Cutt.ly team to see if `localhost` can be added as an accepted origin as those URLs currently fail to convert to a short link, and also to see if URL generation can be limited to the origins `localhost` and `app.klipse.tech`.