### PR TITLE
Add in a dash to applied science library and update

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -4,7 +4,7 @@
         viebel/klipse-clj          #_{:git/url "https://github.com/viebel/klipse-clj.git"
                                       :sha "642bd2815fd046369a60120954b7cad929cde711"} #_{:local/root "/Users/viebel/prj/klipse-clj"} {:mvn/version "10.1.10"}
         org.clojure/core.async {:mvn/version "0.4.474"}
-        appliedscience/js-interop {:mvn/version "0.1.20"}
+        applied-science/js-interop {:mvn/version "0.1.20"}
         viebel/codemirror-parinfer {:mvn/version "0.0.3"}
         cljsjs/markdown {:mvn/version "0.6.0-beta1-0"}
         cljs-http {:mvn/version "0.1.42"}


### PR DESCRIPTION
I was hitting this issue below.

The required namespace "applied-science.js-interop" is not available, it was required by "klipse/utils.cljs".

I noticed that the deps file does not have a dash but the code does not it seems that the version with out a dash was deprecated / moved on clojars so I have updated.

I tried the test web pages and they seem to render, any reason not to update the dependency ?
